### PR TITLE
Add code for generating evals site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+.git
+.github

--- a/modify-quarto-yml.sh
+++ b/modify-quarto-yml.sh
@@ -58,9 +58,9 @@ yq -i '
 
 if [[ "${FORECAST}" == "false" ]]; then
   # remove the forecasts tab
-  yq -i 'with(.website.navbar.left; . |= filter(.href != "forecast.qmd")' "${YML}"
+  yq -i 'with(.website.navbar.left; . |= filter(.href != "forecast.qmd"))' "${YML}"
 fi
 if [[ "${EVAL}" == "false" ]]; then
   # remove the forecasts tab
-  yq -i 'with(.website.navbar.left; . |= filter(.href != "eval.qmd")' "${YML}"
+  yq -i 'with(.website.navbar.left; . |= filter(.href != "eval.qmd"))' "${YML}"
 fi

--- a/modify-quarto-yml.sh
+++ b/modify-quarto-yml.sh
@@ -6,6 +6,7 @@ CFG=${2:-"/site/site-config.yml"}
 ORG=${3:-"hubverse-org"}
 REPO=${4:-"hub-dashboard-template"}
 FORECAST=${5:-"true"}
+EVAL=${6:-"true"}
 
 echo "  Updating site config"
 yq -i '
@@ -57,5 +58,9 @@ yq -i '
 
 if [[ "${FORECAST}" == "false" ]]; then
   # remove the forecasts tab
-  yq -i 'del(.website.navbar.left[1])' "${YML}"
+  yq -i 'with(.website.navbar.left; . |= filter(.href != "forecast.qmd")' "${YML}"
+fi
+if [[ "${EVAL}" == "false" ]]; then
+  # remove the forecasts tab
+  yq -i 'with(.website.navbar.left; . |= filter(.href != "eval.qmd")' "${YML}"
 fi

--- a/render.sh
+++ b/render.sh
@@ -45,19 +45,20 @@ bash /modify-quarto-yml.sh \
   "${FORECASTS}" \
   "${EVALS}"
 if [[ "${FORECASTS}" == "false" ]]; then
-  FORECAST_ROOT="https://raw.githubusercontent.com/$ORG/$REPO/refs/heads/$BRANCH/$DIR"
   echo "  Discarding forecasts page"
   rm /site/pages/forecast.qmd /site/pages/resources/predtimechart.js
 else
+  FORECAST_ROOT="https://raw.githubusercontent.com/$ORG/$REPO/refs/heads/$BRANCH/$DIR"
   # modify the predtimechart js to get content from the correct place
   sed -i -E "s+\{ROOT\}+${FORECAST_ROOT}+" /site/pages/resources/predtimechart.js
 fi
 if [[ "${EVALS}" == "false" ]]; then
-  EVAL_BRANCH="predeval/data"
-  EVAL_ROOT="https://raw.githubusercontent.com/$ORG/$REPO/refs/heads/${EVAL_BRANCH}/$DIR"
   echo "  Discarding (experimental) evals page"
   rm /site/pages/eval.qmd /site/pages/resources/predeval_interface.js
 else
+  # TODO: change this when we publish
+  EVAL_BRANCH="predeval/data"
+  EVAL_ROOT="https://raw.githubusercontent.com/$ORG/$REPO/refs/heads/${EVAL_BRANCH}/$DIR"
   # modify the predtimechart js to get content from the correct place
   sed -i -E "s+\{ROOT\}+${EVAL_ROOT}+" /site/pages/resources/predeval_interface.js
 fi

--- a/render.sh
+++ b/render.sh
@@ -17,7 +17,7 @@ if [[ -z $ORG && -z $REPO ]]; then
   REPO=${full#*/} # bash expansion: delete shortest match before '/'
   REPO=${REPO%/*} # bash expansion: delete shortest match after '/'
 fi
-if [[ -z "${FORECASTS}" && -e "predtimechart-config.yml" ]]; then
+if [[ -z "${FORECASTS}" && -e "/site/predtimechart-config.yml" ]]; then
   # If the forecasts are not specified, we check for the existence of the
   # predtimechart-config.yml and set it to TRUE if it does exist
   FORECASTS="true"
@@ -27,7 +27,7 @@ else
   # does not exist
   FORECASTS=${FORECASTS:-"false"}
 fi
-if [[ - "${EVALS}" && -e "predeval-config.yml" ]]; then
+if [[ -z "${EVALS}" && -e "/site/predeval-config.yml" ]]; then
   EVALS="true"
 else
   EVALS=${EVALS:-"false"}

--- a/static/_quarto.yml
+++ b/static/_quarto.yml
@@ -3,6 +3,7 @@ project:
 
 resources:
   - resources/predtimechart.js
+  - resources/predeval_interface.js
 
 website:
   title: "Hubverse Dashboard Template"

--- a/static/_quarto.yml
+++ b/static/_quarto.yml
@@ -16,6 +16,9 @@ website:
       - text: "Forecasts"
         icon: graph-up
         href: forecast.qmd
+      - text: "Evaluation"
+        icon: table
+        href: eval.qmd
     right:
       - text: "Hub"
         icon: database

--- a/static/eval.qmd
+++ b/static/eval.qmd
@@ -1,0 +1,13 @@
+---
+repo-actions: false
+include-after-body:
+  text: |
+    <script type="module" src="includes/predeval_interface.js"></script>
+---
+
+
+::: {#predEval_row .grid .column-screen-inset}
+
+this is replaced
+
+:::

--- a/static/eval.qmd
+++ b/static/eval.qmd
@@ -2,7 +2,7 @@
 repo-actions: false
 include-after-body:
   text: |
-    <script type="module" src="includes/predeval_interface.js"></script>
+    <script type="module" src="resources/predeval_interface.js"></script>
 ---
 
 

--- a/static/resources/predeval_interface.js
+++ b/static/resources/predeval_interface.js
@@ -15,8 +15,6 @@ async function _fetchData(target, eval_window, disaggregate_by) {
     // ex taskIDs: {"scenario_id": "A-2022-05-09", "location": "US"} . NB: key order not sorted
     console.info("_fetchData(): entered.", `"${target}"`, `"${eval_window}"`, `"${disaggregate_by}"`);
 
-    // const targetKeyStr = replace_chars(targetKey);
-
     let target_path;
     if (disaggregate_by === '(None)') {
       target_path = `${root}scores/${target}/${eval_window}/scores.csv`;
@@ -24,9 +22,6 @@ async function _fetchData(target, eval_window, disaggregate_by) {
       target_path = `${root}scores/${target}/${eval_window}/${disaggregate_by}/scores.csv`;
     }
     return d3.csv(target_path);
-    // return fetch(target_path)
-    //     .then(response => response.text())
-    //     .then(data => parse(data));
 }
 
 
@@ -36,7 +31,7 @@ fetch(`${root}/predeval-options.json`)
     .then((data) => {
         console.info("fetch(): done. calling App.initialize().", data);
 
-        // componentDiv, _fetchData, isIndicateRedraw, options, _calcUemForecasts:
+        // componentDiv, _fetchData, options:
         App.initialize('predEval_row', _fetchData, data);
     })
     .then(function() {

--- a/static/resources/predeval_interface.js
+++ b/static/resources/predeval_interface.js
@@ -9,7 +9,7 @@ function replace_chars(the_string) {
     return the_string.replace(/[^a-zA-Z0-9-_]/g, '-');
 }
 
-const root = "https://raw.githubusercontent.com/elray1/flusight-dashboard/refs/heads/predeval/data/";
+const root = "{ROOT}";
 
 async function _fetchData(target, eval_window, disaggregate_by) {
     // ex taskIDs: {"scenario_id": "A-2022-05-09", "location": "US"} . NB: key order not sorted

--- a/static/resources/predeval_interface.js
+++ b/static/resources/predeval_interface.js
@@ -1,0 +1,61 @@
+import App from "https://cdn.jsdelivr.net/gh/hubverse-org/predeval@0.0.1/dist/predeval.bundle.js";
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
+
+document.predeval = App;  // for debugging
+document.d3m = d3;  // for debugging
+
+function replace_chars(the_string) {
+    // replace all non-alphanumeric characters, except dashes and underscores, with a dash
+    return the_string.replace(/[^a-zA-Z0-9-_]/g, '-');
+}
+
+const root = "https://raw.githubusercontent.com/elray1/flusight-dashboard/refs/heads/predeval/data/";
+
+async function _fetchData(target, eval_window, disaggregate_by) {
+    // ex taskIDs: {"scenario_id": "A-2022-05-09", "location": "US"} . NB: key order not sorted
+    console.info("_fetchData(): entered.", `"${target}"`, `"${eval_window}"`, `"${disaggregate_by}"`);
+
+    // const targetKeyStr = replace_chars(targetKey);
+
+    let target_path;
+    if (disaggregate_by === '(None)') {
+      target_path = `${root}scores/${target}/${eval_window}/scores.csv`;
+    } else {
+      target_path = `${root}scores/${target}/${eval_window}/${disaggregate_by}/scores.csv`;
+    }
+    return d3.csv(target_path);
+    // return fetch(target_path)
+    //     .then(response => response.text())
+    //     .then(data => parse(data));
+}
+
+
+// load options and then initialize the component
+fetch(`${root}/predeval-options.json`)
+    .then(response => response.json())
+    .then((data) => {
+        console.info("fetch(): done. calling App.initialize().", data);
+
+        // componentDiv, _fetchData, isIndicateRedraw, options, _calcUemForecasts:
+        App.initialize('predEval_row', _fetchData, data);
+    })
+    .then(function() {
+        // ZNK 2024-09-16: update for bootstrap 5
+        var divs = document.querySelectorAll("div[class^='col-md']");
+        for (var div of divs) {
+          if (div.className.match("g-col") == null) {
+            var n = div.className.match("col-md-(.{1,2})")[1];
+            div.classList.add("g-col-"+n);
+          }
+        }
+    });
+
+window.addEventListener('DOMContentLoaded', function() {
+  var divs = document.querySelectorAll("div[class^='col-md']");
+  for (var div of divs) {
+    if (div.className.match("g-col") == null) {
+      var n = div.className.match("col-md-(.{1,2})")[1];
+      div.classList.add("g-col-"+n);
+    }
+  }
+});


### PR DESCRIPTION
I've modified the docker scripts to generate the evals site if the config file exists.

I tested it locally on https://github.com/elray1/flusight-dashboard/ to confirm it works:

```bash
rm -rf pages/includes/ pages/eval.qmd
&& yq -i 'del(.pages)' site-config.yml \
&& docker run --platform=linux/amd64 --rm -it \
-v "$(pwd)":"/site" \
ghcr.io/hubverse-org/hub-dash-site-builder:znk-add-evals \
bash render.sh elray1 flusight-dashboard
```

```
📂 Copying site skeleton
  Updating site config
🏗  Building the site
[1/3] eval.qmd
[2/3] index.qmd
[3/3] forecast.qmd

Output created: _site/index.html

😃 All done!
```

I've also confirmed that it does not affect current setups:

<details>
<summary>Test with flu sight dashboard</summary>

```bash
docker run --platform=linux/amd64 --rm -it \
-v "$(pwd)":"/site" \
ghcr.io/hubverse-org/hub-dash-site-builder:znk-add-evals \
bash render.sh reichlab flusight-dashboard
```

```
Unable to find image 'ghcr.io/hubverse-org/hub-dash-site-builder:znk-add-evals' locally
znk-add-evals: Pulling from hubverse-org/hub-dash-site-builder
5e00d3b7d3be: Download complete 
15a54f93474f: Download complete 
66b5a61787ef: Download complete 
065c5d5fa965: Download complete 
bcc60769dde5: Download complete 
Digest: sha256:951cb7e6f2b554831f84493318c6f2808aa461a1f1426ce1e6b15e0e89390ef7
Status: Downloaded newer image for ghcr.io/hubverse-org/hub-dash-site-builder:znk-add-evals
📂 Copying site skeleton
  Updating site config
  Discarding (experimental) evals page
🏗  Building the site
[1/2] index.qmd
[2/2] forecast.qmd

Output created: _site/index.html

😃 All done!
```

</details>

<details><summary>Test with Variant Nowcast Hub dashboard</summary>
<p>

```bash
docker run --platform=linux/amd64 --rm -it \
-v "$(pwd)":"/site" \
ghcr.io/hubverse-org/hub-dash-site-builder:znk-add-evals \
bash render.sh reichlab variant-nowcast-hub-dashboard
```

```
📂 Copying site skeleton
  Updating site config
  Discarding forecasts page
  Discarding (experimental) evals page
🏗  Building the site
[1/8] 2024-12-18-report.md
[2/8] 2025-01-01-report.md
[3/8] index.qmd
[4/8] 2024-12-11-report.md
[5/8] 2024-11-27-report.md
[6/8] 2024-12-04-report.md
[7/8] 2024-12-25-report.md
[8/8] 2025-01-08-report.md

Output created: _site/index.html

😃 All done!
```

</p>
</details> 
