### PR TITLE
Update workflow security

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          push: ${{ github.event_name == "release" }}
+          push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
@@ -63,6 +63,6 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: ${{ github.event_name == "release" }}
+          push-to-registry: ${{ github.event_name == 'release' }}
       
 

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -25,9 +25,9 @@ jobs:
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
-      packages: ${{ github.event_name == "release" && write || none }}
-      attestations: ${{ github.event_name == "release" && write || none }}
-      id-token: ${{ github.event_name == "release" && write || none }}
+      packages: write
+      attestations: write
+      id-token: write
       # 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -2,6 +2,8 @@ name: Create and publish a Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
+  release:
+    types: [published]
   push:
     paths:
       - render.sh
@@ -23,9 +25,9 @@ jobs:
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
+      packages: ${{ github.event_name == "release" && write || none }}
+      attestations: ${{ github.event_name == "release" && write || none }}
+      id-token: ${{ github.event_name == "release" && write || none }}
       # 
     steps:
       - name: Checkout repository
@@ -51,7 +53,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == "release" }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
@@ -61,6 +63,6 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: ${{ github.event_name == "release" }}
       
 


### PR DESCRIPTION
This updates the build workflow to only push to the registry on release, which will address #16

I say address and not fix because it still does not prevent someone from modifying the workflow on a branch to set `push: true` and triggering it from the workflow dispatch. 

Another solution to this would be to create one workflow for test and one for release, but that will suffer from the same vulnerability (e.g. someone could modify the permissions of the test workflow)