### PR TITLE
Bump predevals version to 1.0.1

### DIFF
--- a/static/resources/predevals_interface.js
+++ b/static/resources/predevals_interface.js
@@ -1,4 +1,4 @@
-import App from "https://cdn.jsdelivr.net/gh/hubverse-org/predevals@1.0.0/dist/predevals.bundle.js";
+import App from "https://cdn.jsdelivr.net/gh/hubverse-org/predevals@1.0.1/dist/predevals.bundle.js";
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 
 document.predevals = App;  // for debugging


### PR DESCRIPTION
[predevals v1.0.1](https://github.com/hubverse-org/predevals/releases/tag/v1.0.1) [fixes a bug](https://github.com/hubverse-org/predevals/pull/39/files/7cc2857b6b91075e4d5122c5d80b4c66c9c22083#r2005810080) where it tried to access properties of an undefined object if a `task_id_text` mapping wasn't provided.