### PR TITLE
fix broken workflow

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -121,7 +121,7 @@ jobs:
     needs: [build-image]
     name: "Publish Image"
     runs-on: ubuntu-latest
-    if: ${{ fromJSON(env.PUBLISH) }}
+    if: ${{ github.event_name == 'push' && startsWith(github.event.push.ref, 'refs/tag') || (github.event.workflow_dispatch.ref == '/refs/head/main' && inputs.publish) }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -151,13 +151,13 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
         with:
           tags: ${{ needs.build-image.outputs.tags }}
-          push: true
+          push: ${{ fromJSON(env.PUBLISH) }}
           labels: ${{ needs.build-image.outputs.labels }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: ${{ fromJSON(env.PUBLISH) }}
 
 


### PR DESCRIPTION
This fixes the previous PR where the workflow was broken because I dared---DARED to use an environment variable

> [Invalid workflow file: .github/workflows/build-container.yaml#L124](https://github.com/hubverse-org/hub-dash-site-builder/actions/runs/14181311430/workflow)
The workflow is not valid. .github/workflows/build-container.yaml (Line: 124, Col: 9): Unrecognized named-value: 'env'. Located at position 10 within expression: fromJSON(env.PUBLISH)
