### PR TITLE
use latest minor release for predevals and predtimechart

### DIFF
--- a/static/resources/predevals_interface.js
+++ b/static/resources/predevals_interface.js
@@ -1,4 +1,4 @@
-import App from "https://cdn.jsdelivr.net/gh/hubverse-org/predevals@1.0.2/dist/predevals.bundle.js";
+import App from "https://cdn.jsdelivr.net/gh/hubverse-org/predevals@v1/dist/predevals.bundle.js";
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 
 document.predevals = App;  // for debugging

--- a/static/resources/predtimechart.js
+++ b/static/resources/predtimechart.js
@@ -1,4 +1,4 @@
-import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@3.0.0/dist/predtimechart.bundle.js';
+import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@v3/dist/predtimechart.bundle.js';
 document.predtimechart = App;  // for debugging
 
 function replace_chars(the_string) {


### PR DESCRIPTION
This will simplify updates to the javascript components for the
pages because we would no longer require a subsequent release of
this image (assuming there are no breaking changes for the JS
components)
