### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/static/_quarto.yml
+++ b/static/_quarto.yml
@@ -27,7 +27,7 @@ website:
   page-footer:
     right:
       - text: "Built with the Hubverse dashboard"
-        href: https://hubverse.io/en/latest/user-guide/dashboards.html
+        href: https://docs.hubverse.io/en/latest/user-guide/dashboards.html
 format:
   html:
     from: markdown+emoji


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.