### PR TITLE
add fixed model name column with horizontal scrolling on all other columns

### DIFF
--- a/static/resources/header.html
+++ b/static/resources/header.html
@@ -14,10 +14,14 @@
 <!-- plotly -->
 <script src="https://cdn.plot.ly/plotly-2.12.1.min.js"></script>
 
-<!-- DataTables and ColumnControl -->
+<!-- DataTables, including ColumnControl and FixedColumns extensions -->
 <link rel="stylesheet" href="https://cdn.datatables.net/2.3.6/css/dataTables.bootstrap5.min.css">
 <link rel="stylesheet" href="https://cdn.datatables.net/columncontrol/1.2.0/css/columnControl.bootstrap5.min.css">
 <script src="https://cdn.datatables.net/2.3.6/js/dataTables.min.js"></script>
 <script src="https://cdn.datatables.net/2.3.6/js/dataTables.bootstrap5.min.js"></script>
 <script src="https://cdn.datatables.net/columncontrol/1.2.0/js/dataTables.columnControl.min.js"></script>
 <script src="https://cdn.datatables.net/columncontrol/1.2.0/js/columnControl.bootstrap5.min.js"></script>
+
+<link rel="stylesheet" href="https://cdn.datatables.net/fixedcolumns/5.0.4/css/fixedColumns.bootstrap5.min.css">
+<script src="https://cdn.datatables.net/fixedcolumns/5.0.4/js/dataTables.fixedColumns.min.js"></script>
+<script src="https://cdn.datatables.net/fixedcolumns/5.0.4/js/fixedColumns.bootstrap5.min.js"></script>


### PR DESCRIPTION
Implements [add fixed model name column with horizontal scrolling on all other columns #49] via the [DataTables FixedColumns](https://datatables.net/extensions/fixedcolumns/) extension.

Reviewer notes:
- The only change is new \<link> and \<script> dependencies in **static/resources/header.html**.